### PR TITLE
Update pre-commit hooks and add .prettierignore

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,8 +1,8 @@
 pre-commit:
   commands:
-    lint:
-      run: pnpm ng lint --fix
-
     format:
-      glob: "*.{ts,html,css,json,md}"
-      run: pnpm prettier --write {staged_files}
+      glob: '*.{ts,html,css,json,md}'
+      run: pnpm prettier --write {staged_files} && git add {staged_files}
+
+    lint:
+      run: pnpm ng lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Lockfiles
+pnpm-lock.yaml
+package-lock.json
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "ng lint",
-    "format": "prettier . --write"
+    "format": "prettier . --write",
+    "prepare": "lefthook install"
   },
   "prettier": {
     "printWidth": 100,


### PR DESCRIPTION
Enhance pre-commit hooks to run lint without the --fix option and ensure prettier ignores lock files.