### PR TITLE
Add dependency groups for npm and GitHub Actions in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,25 @@
 # https://containers.dev/guide/dependabot
 
 version: 2
+
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: weekly
+      interval: 'weekly'
+    groups:
+      npm-non-major:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: weekly
+      interval: 'weekly'
+    groups:
+      github-actions-all:
+        patterns:
+          - '*'


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to improve how dependency updates are grouped and scheduled. The main changes add grouping rules for both npm and GitHub Actions dependencies, allowing minor and patch updates to be batched together for easier management.

**Dependabot configuration improvements:**

* Added `groups` configuration for npm dependencies to batch all minor and patch updates together under the `npm-non-major` group.
* Added `groups` configuration for GitHub Actions dependencies to batch all updates together under the `github-actions-all` group.
* Standardized the schedule interval format to use quoted strings for consistency.