### PR TITLE
Add Windows shell override for just

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 set shell := ["bash", "-c"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"]
 
 default:
     @just --list


### PR DESCRIPTION
## Summary
- Add a `windows-shell` setting in `justfile` so recipes run under PowerShell on Windows.
- Keep the existing Bash shell setting unchanged for non-Windows environments.

## Testing
- Not run (not requested).